### PR TITLE
Update `requirements.txt` from `install` -> `pip-install`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ffmpeg-python==0.2.0
 future==1.0.0
 idna==3.7
 iniconfig==2.0.0
-install==1.3.5
+pip-install==1.3.5
 packaging==24.0
 pathvalidate==3.2.0
 pluggy==1.5.0


### PR DESCRIPTION
Change from `install` to `pip-install`; the package was renamed: https://pypi.org/project/pip-install/